### PR TITLE
WIP: API OpenID Updates

### DIFF
--- a/app/controllers/api/v1/aspects_controller.rb
+++ b/app/controllers/api/v1/aspects_controller.rb
@@ -3,12 +3,12 @@
 module Api
   module V1
     class AspectsController < Api::V1::BaseController
-      before_action only: %i[index show] do
-        require_access_token %w[read]
+      before_action except: %i[create update destroy] do
+        require_access_token %w[contacts:read]
       end
 
       before_action only: %i[create update destroy] do
-        require_access_token %w[read write]
+        require_access_token %w[contacts:modify]
       end
 
       def index

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -52,6 +52,14 @@ module Api
       def time_pager(query)
         Api::Paging::RestPaginatorBuilder.new(query, request).time_pager(params)
       end
+
+      def private_read?
+        access_token? %w[private:read]
+      end
+
+      def private_modify?
+        access_token? %w[private:modify]
+      end
     end
   end
 end

--- a/app/controllers/api/v1/contacts_controller.rb
+++ b/app/controllers/api/v1/contacts_controller.rb
@@ -5,12 +5,12 @@ require "api/paging/index_paginator"
 module Api
   module V1
     class ContactsController < Api::V1::BaseController
-      before_action only: %i[index] do
-        require_access_token %w[read]
+      before_action except: %i[create destroy] do
+        require_access_token %w[contacts:read]
       end
 
       before_action only: %i[create destroy] do
-        require_access_token %w[read write]
+        require_access_token %w[contacts:modify]
       end
 
       rescue_from ActiveRecord::RecordNotFound do

--- a/app/controllers/api/v1/conversations_controller.rb
+++ b/app/controllers/api/v1/conversations_controller.rb
@@ -5,12 +5,8 @@ module Api
     class ConversationsController < Api::V1::BaseController
       include ConversationsHelper
 
-      before_action only: %i[create index show] do
-        require_access_token %w[read]
-      end
-
-      before_action only: %i[create destroy] do
-        require_access_token %w[read write]
+      before_action do
+        require_access_token %w[conversations]
       end
 
       rescue_from ActiveRecord::RecordNotFound do

--- a/app/controllers/api/v1/likes_controller.rb
+++ b/app/controllers/api/v1/likes_controller.rb
@@ -3,12 +3,8 @@
 module Api
   module V1
     class LikesController < Api::V1::BaseController
-      before_action only: %i[show] do
-        require_access_token %w[read]
-      end
-
-      before_action only: %i[create destroy] do
-        require_access_token %w[write]
+      before_action do
+        require_access_token %w[interactions public:read]
       end
 
       rescue_from ActiveRecord::RecordNotFound do
@@ -16,10 +12,12 @@ module Api
       end
 
       rescue_from ActiveRecord::RecordInvalid do
-        render json: I18n.t("api.endpoint_errors.likes.user_not_allowed_to_like"), status: :not_found
+        render json: I18n.t("api.endpoint_errors.likes.user_not_allowed_to_like"), status: :unprocessable_entity
       end
 
       def show
+        post = post_service.find!(params[:post_id])
+        raise ActiveRecord::RecordInvalid unless post.public? || private_read?
         likes_query = like_service.find_for_post(params[:post_id])
         likes_page = index_pager(likes_query).response
         likes_page[:data] = likes_page[:data].map {|x| like_json(x) }
@@ -27,6 +25,8 @@ module Api
       end
 
       def create
+        post = post_service.find!(params[:post_id])
+        raise ActiveRecord::RecordInvalid unless post.public? || private_modify?
         like_service.create(params[:post_id])
       rescue ActiveRecord::RecordInvalid => e
         return render json: I18n.t("api.endpoint_errors.likes.like_exists"), status: :unprocessable_entity if
@@ -37,6 +37,8 @@ module Api
       end
 
       def destroy
+        post = post_service.find!(params[:post_id])
+        raise ActiveRecord::RecordInvalid unless post.public? || private_modify?
         success = like_service.unlike_post(params[:post_id])
         if success
           head :no_content
@@ -45,11 +47,15 @@ module Api
         end
       end
 
+      private
+
       def like_service
         @like_service ||= LikeService.new(current_user)
       end
 
-      private
+      def post_service
+        @post_service ||= PostService.new(current_user)
+      end
 
       def like_json(like)
         LikesPresenter.new(like).as_api_json

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -3,12 +3,8 @@
 module Api
   module V1
     class MessagesController < Api::V1::BaseController
-      before_action only: %i[create] do
-        require_access_token %w[read write]
-      end
-
-      before_action only: %i[index] do
-        require_access_token %w[read]
+      before_action do
+        require_access_token %w[conversations]
       end
 
       rescue_from ActiveRecord::RecordNotFound do

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -3,12 +3,8 @@
 module Api
   module V1
     class NotificationsController < Api::V1::BaseController
-      before_action except: %i[update] do
-        require_access_token %w[read]
-      end
-
-      before_action only: %i[update] do
-        require_access_token %w[write]
+      before_action do
+        require_access_token %w[notifications]
       end
 
       rescue_from ActiveRecord::RecordNotFound do

--- a/app/controllers/api/v1/reshares_controller.rb
+++ b/app/controllers/api/v1/reshares_controller.rb
@@ -3,12 +3,12 @@
 module Api
   module V1
     class ResharesController < Api::V1::BaseController
-      before_action only: %i[show] do
-        require_access_token %w[read]
+      before_action except: %i[create] do
+        require_access_token %w[public:read]
       end
 
       before_action only: %i[create] do
-        require_access_token %w[read write]
+        require_access_token %w[public:modify]
       end
 
       rescue_from ActiveRecord::RecordNotFound do

--- a/app/controllers/api/v1/tag_followings_controller.rb
+++ b/app/controllers/api/v1/tag_followings_controller.rb
@@ -3,16 +3,12 @@
 module Api
   module V1
     class TagFollowingsController < Api::V1::BaseController
-      before_action only: %i[index] do
-        require_access_token %w[read]
+      before_action except: %i[create destroy] do
+        require_access_token %w[tags:read]
       end
 
       before_action only: %i[create destroy] do
-        require_access_token %w[read write]
-      end
-
-      rescue_from StandardError do
-        render json: I18n.t("api.endpoint_errors.tags.cant_process"), status: :bad_request
+        require_access_token %w[tags:modify]
       end
 
       def index
@@ -22,6 +18,8 @@ module Api
       def create
         tag_followings_service.create(params.require(:name))
         head :no_content
+      rescue StandardError
+        render json: I18n.t("api.endpoint_errors.tags.cant_process"), status: :unprocessable_entity
       end
 
       def destroy

--- a/app/models/api/openid_connect/authorization.rb
+++ b/app/models/api/openid_connect/authorization.rb
@@ -18,7 +18,32 @@ module Api
 
       scope :with_redirect_uri, ->(given_uri) { where redirect_uri: given_uri }
 
-      SCOPES = %w(openid sub aud name nickname profile picture read write)
+      SCOPES = %w[
+        birthdate
+        contacts:modify
+        contacts:read
+        conversations
+        email
+        gender
+        interactions
+        locale
+        name
+        nickname
+        notifications
+        openid
+        picture
+        private:modify
+        private:read
+        profile
+        profile
+        profile:modify
+        public:modify
+        public:read
+        sub
+        tags:modify
+        tags:read
+        updated_at
+      ].freeze
 
       def setup
         self.refresh_token = SecureRandom.hex(32)

--- a/app/services/post_service.rb
+++ b/app/services/post_service.rb
@@ -35,8 +35,12 @@ class PostService
     mark_mention_notifications_read(post_id)
   end
 
-  def destroy(post_id)
-    post = find!(post_id)
+  def destroy(post_id, private_allowed=true)
+    post = if private_allowed
+             find_non_public_by_guid_or_id_with_user!(post_id)
+           else
+             find_public!(post_id)
+           end
     raise Diaspora::NotMine unless post.author == user.person
     user.retract(post)
   end

--- a/config/locales/diaspora/en.yml
+++ b/config/locales/diaspora/en.yml
@@ -905,6 +905,8 @@ en:
           deny: "Deny"
           bad_request: "Missing client id or redirect URI"
           client_id_not_found: "No client with client_id %{client_id} with redirect URI %{redirect_uri} found"
+          private_contacts_linkage_error: "private:read and private:modify require contacts:read as well"
+          unknown_scope: "Unknown scope: #{scope_name}"
         destroy:
           fail: "The attempt to revoke the authorization with ID %{id} failed"
       user_applications:
@@ -920,31 +922,73 @@ en:
       scopes:
         openid:
           name: "basic profile"
-          description: "This allows the application to read your basic profile"
+          description: "This grants read access to basic profile information to the application."
         sub:
           name: "sub"
-          description: "This grants sub permissions to the application"
-        aud:
-          name: "aud"
-          description: "This grants aud permissions to the application"
+          description: "This grants sub permissions to the application."
         name:
           name: "name"
-          description: "This grants name permissions to the application"
+          description: "This grants read access to name data to the application."
         nickname:
           name: "nickname"
-          description: "This grants nickname permissions to the application"
-        profile:
-          name: "extended profile"
-          description: "This allows the application to read your extended profile"
+          description: "This grants read access to nickname data to the application."
         picture:
           name: "picture"
-          description: "This grants picture permissions to the application"
-        read:
-          name: "read profile, stream and conversations"
-          description: "This allows the application to read your stream, your conversations and your complete profile"
-        write:
-          name: "send posts, conversations and reactions"
-          description: "This allows the application to send new posts, write conversations, and send reactions"
+          description: "This grants read access to user's profile picture data to the application."
+        gender:
+          name: "gender"
+          description: "This grants read access to the user's gendere data to the application."
+        birthdate:
+          name: "birthdate"
+          description: "This grants read access ot the user's birthdate to the application."
+        locale:
+          name: "locale"
+          description: "This grants read access ot the user's locale to the application."
+        updated_at:
+          name: "updated_at"
+          description: "This grants read access to the user's profile update time to the application."
+        'contacts:read':
+          name: "contacts:read"
+          description: "This grants read permissions to contacts and related data (like aspects) to the application."
+        'contacts:modify':
+          name: "contacts:modify"
+          description: "This grants write permissions to contacts and related data (like aspects) to the application."
+        conversations:
+          name: "conversations"
+          description: "This grants read/write permission to private messaging to the application."
+        email:
+          name: "email"
+          description: "This grants read access to the user's email address to the application."
+        interactions:
+          name: "interactions"
+          description: "This grants read and write permissions on interacting wth posts to the application."
+        notifications:
+          name: "notifications"
+          description: "This grants read and write permissions on interactions for the user to the application."
+        'private:read':
+          name: "private:read"
+          description: "This grants read privileges on private posts and streams to the application."
+        'private:modify':
+          name: "private:modify"
+          description: "This grants modification privileges on private posts and streams, including allowing private sharing, to the application."
+        'public:read':
+          name: "public:read"
+          description: "This grants read permissions on public posts, interactions, and user data to the application."
+        'public:modify':
+          name: "updated_at"
+          description: "This grants write permissions on public posts (including public post writing), interactions, and user data to the application."
+        profile:
+          name: "extended profile"
+          description: "This grants read access to extendend profile data to the application."
+        'profile:modify':
+          name: "profile:modify"
+          description: "This grants user profile update permissions to the application."
+        'tags:read':
+          name: "tags:read"
+          description: "This grants read access to user's followed tags and tag streams to the application."
+        'tags:modify':
+          name: "tags:modify"
+          description: "This grants modification access to user's followed tags to the application."
       error_page:
         title: "Oh! Something went wrong :("
         contact_developer: "You should contact the developer of the application and include the following detailed error message:"

--- a/lib/api/openid_connect/authorization_point/endpoint.rb
+++ b/lib/api/openid_connect/authorization_point/endpoint.rb
@@ -50,9 +50,16 @@ module Api
           replace_profile_scope_with_specific_claims(req)
           @scopes = req.scope.map {|scope|
             scope.tap do |scope_name|
-              req.invalid_scope! "Unknown scope: #{scope_name}" unless auth_scopes.include? scope_name
+              req.invalid_scope! I18n.t("api.openid_connect.authorizations.new.unknown_scope") \
+                unless auth_scopes.include?(scope_name)
             end
           }
+
+          @scopes.push("public:read") unless @scopes.include?("public:read")
+          has_private_scope = @scopes.include?("private:read") || @scopes.include?("private:modify")
+          has_contacts_scope = @scopes.include? "contacts:read"
+          req.invalid_scope! I18n.t("api.openid_connect.authorizations.new.private_contacts_linkage_error") \
+            if has_private_scope && !has_contacts_scope
         end
 
         def auth_scopes

--- a/lib/api/openid_connect/authorization_point/endpoint_start_point.rb
+++ b/lib/api/openid_connect/authorization_point/endpoint_start_point.rb
@@ -17,7 +17,7 @@ module Api
         end
 
         def replace_profile_scope_with_specific_claims(req)
-          profile_claims = %w(sub aud name nickname profile picture)
+          profile_claims = %w[sub name nickname profile picture gender birthdate locale updated_at]
           scopes_as_claims = req.scope.flat_map {|scope| scope == "profile" ? profile_claims : [scope] }.uniq
           req.update_param("scope", scopes_as_claims)
         end

--- a/lib/api/openid_connect/protected_resource_endpoint.rb
+++ b/lib/api/openid_connect/protected_resource_endpoint.rb
@@ -29,11 +29,15 @@ module Api
       attr_reader :current_token
 
       def require_access_token(required_scopes)
+        raise Rack::OAuth2::Server::Resource::Bearer::Forbidden.new(:insufficient_scope) unless
+          access_token?(required_scopes)
+      end
+
+      def access_token?(required_scopes)
         @current_token = request.env[Rack::OAuth2::Server::Resource::ACCESS_TOKEN]
         raise Rack::OAuth2::Server::Resource::Bearer::Unauthorized.new("Unauthorized user") unless
           @current_token && @current_token.authorization
-        raise Rack::OAuth2::Server::Resource::Bearer::Forbidden.new(:insufficient_scope) unless
-          @current_token.authorization.try(:accessible?, required_scopes)
+        @current_token.authorization.try(:accessible?, required_scopes)
       end
     end
   end

--- a/lib/api/openid_connect/token_endpoint.rb
+++ b/lib/api/openid_connect/token_endpoint.rb
@@ -27,6 +27,7 @@ module Api
           auth = Api::OpenidConnect::Authorization.with_redirect_uri(req.redirect_uri).use_code(req.code)
           req.invalid_grant! if auth.blank?
           res.access_token = auth.create_access_token
+          res.access_token.refresh_token = auth.refresh_token
           if auth.accessible? "openid"
             id_token = auth.create_id_token
             res.id_token = id_token.to_jwt(access_token: res.access_token)

--- a/spec/controllers/api/openid_connect/authorizations_controller_spec.rb
+++ b/spec/controllers/api/openid_connect/authorizations_controller_spec.rb
@@ -253,7 +253,7 @@ describe Api::OpenidConnect::AuthorizationsController, type: :request do
         before do
           get new_api_openid_connect_authorization_path, params: {client_id: client.client_id,
               redirect_uri: "http://localhost:3000/", response_type: "id_token",
-              scope: "openid read", nonce: 413_093_098_3, state: 413_093_098_3}
+              scope: "openid interactions", nonce: 413_093_098_3, state: 413_093_098_3}
         end
 
         it "should receive another authorization request" do
@@ -380,12 +380,71 @@ describe Api::OpenidConnect::AuthorizationsController, type: :request do
         end
       end
     end
+
+    context "ensure public:read always there" do
+      it "added with only openid" do
+        get new_api_openid_connect_authorization_path, params: {client_id:     client.client_id,
+                                                                redirect_uri:  "http://localhost:3000/",
+                                                                response_type: "id_token token",
+                                                                scope:         "openid",
+                                                                nonce:         418_093_098_3,
+                                                                state:         418_093_098_3}
+        post api_openid_connect_authorizations_path, params: {approve: "true"}
+        expect(alice.reload.authorizations.first.scopes).to include("public:read")
+      end
+    end
+
+    context "with contacts:read and private linkage requirement" do
+      it "fails without contacts:read on private:read" do
+        scopes = "openid private:read"
+        get new_api_openid_connect_authorization_path, params: {client_id:     client.client_id,
+                                                                redirect_uri:  "http://localhost:3000/",
+                                                                response_type: "id_token token",
+                                                                scope:         scopes,
+                                                                nonce:         418_093_098_3,
+                                                                state:         418_093_098_3}
+        expect(response.status).to eq(302)
+      end
+
+      it "fails without contacts:read on private:modify" do
+        scopes = "openid private:modify"
+        get new_api_openid_connect_authorization_path, params: {client_id:     client.client_id,
+                                                                redirect_uri:  "http://localhost:3000/",
+                                                                response_type: "id_token token",
+                                                                scope:         scopes,
+                                                                nonce:         418_093_098_3,
+                                                                state:         418_093_098_3}
+        expect(response.status).to eq(302)
+      end
+
+      it "succeeds with contacts:read on private:read" do
+        scopes = "openid contacts:read private:read"
+        get new_api_openid_connect_authorization_path, params: {client_id:     client.client_id,
+                                                                redirect_uri:  "http://localhost:3000/",
+                                                                response_type: "id_token token",
+                                                                scope:         scopes,
+                                                                nonce:         418_093_098_3,
+                                                                state:         418_093_098_3}
+        expect(response.status).to eq(200)
+      end
+
+      it "succeeds with contacts:read on private:modify" do
+        scopes = "openid contacts:read private:modify"
+        get new_api_openid_connect_authorization_path, params: {client_id:     client.client_id,
+                                                                redirect_uri:  "http://localhost:3000/",
+                                                                response_type: "id_token token",
+                                                                scope:         scopes,
+                                                                nonce:         418_093_098_3,
+                                                                state:         418_093_098_3}
+        expect(response.status).to eq(200)
+      end
+    end
   end
 
   describe "#destroy" do
     context "with existent authorization" do
       it "removes the authorization" do
-        auth_with_read = FactoryGirl.create(:auth_with_read, o_auth_application: client)
+        auth_with_read = FactoryGirl.create(:auth_with_profile_only, o_auth_application: client)
         delete api_openid_connect_authorization_path(auth_with_read.id)
         expect(Api::OpenidConnect::Authorization.find_by(id: auth_with_read.id)).to be_nil
       end

--- a/spec/controllers/api/openid_connect/token_endpoint_controller_spec.rb
+++ b/spec/controllers/api/openid_connect/token_endpoint_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Api::OpenidConnect::TokenEndpointController, type: :controller, suppress_csrf_verification: :none do
-  let(:auth) { FactoryGirl.create(:auth_with_read) }
+  let(:auth) { FactoryGirl.create(:auth_with_profile_only) }
 
   describe "#create" do
     it "returns 200 on success" do
@@ -14,6 +14,17 @@ describe Api::OpenidConnect::TokenEndpointController, type: :controller, suppres
         client_secret: auth.o_auth_application.client_secret
       }
       expect(response.code).to eq("200")
+    end
+
+    it "refresh returns 200 on success" do
+      post :create, params: {
+        grant_type:    "refresh_token",
+        refresh_token: auth.refresh_token,
+        client_id:     auth.o_auth_application.client_id,
+        client_secret: auth.o_auth_application.client_secret
+      }
+      expect(response.code).to eq("200")
+      puts response.body
     end
   end
 end

--- a/spec/controllers/api/openid_connect/user_applications_spec.rb
+++ b/spec/controllers/api/openid_connect/user_applications_spec.rb
@@ -4,7 +4,7 @@ describe Api::OpenidConnect::UserApplicationsController, type: :controller do
   before do
     @app = FactoryGirl.create(:o_auth_application_with_xss)
     @user = FactoryGirl.create :user
-    FactoryGirl.create :auth_with_read, user: @user, o_auth_application: @app
+    FactoryGirl.create :auth_with_profile_only, user: @user, o_auth_application: @app
     sign_in @user, scope: :user
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -403,28 +403,59 @@ FactoryGirl.define do
     redirect_uris %w(http://localhost:3000/)
   end
 
-  factory :auth_with_read, class: Api::OpenidConnect::Authorization do
+  factory :auth_with_profile_only, class: Api::OpenidConnect::Authorization do
     o_auth_application
     user
-    scopes %w(openid sub aud profile picture nickname name read)
+    scopes %w[openid profile]
     after(:build) {|m|
       m.redirect_uri = m.o_auth_application.redirect_uris[0]
     }
   end
 
-  factory :auth_with_read_and_ppid, class: Api::OpenidConnect::Authorization do
+  factory :auth_with_profile_and_ppid, class: Api::OpenidConnect::Authorization do
     association :o_auth_application, factory: :o_auth_application_with_ppid
     user
-    scopes %w(openid sub aud profile picture nickname name read)
+    scopes %w[openid sub profile picture nickname name]
     after(:build) {|m|
       m.redirect_uri = m.o_auth_application.redirect_uris[0]
     }
   end
 
-  factory :auth_with_read_and_write, class: Api::OpenidConnect::Authorization do
+  factory :auth_with_all_scopes, class: Api::OpenidConnect::Authorization do
     o_auth_application
     association :user, factory: :user_with_aspect
-    scopes %w(openid sub aud profile picture nickname name read write)
+    scopes Api::OpenidConnect::Authorization::SCOPES
+    after(:build) {|m|
+      m.redirect_uri = m.o_auth_application.redirect_uris[0]
+    }
+  end
+
+  factory :auth_with_all_scopes_not_private, class: Api::OpenidConnect::Authorization do
+    o_auth_application
+    association :user, factory: :user_with_aspect
+    scopes %w[openid sub name nickname profile picture gender birthdate locale updated_at contacts:read contacts:modify
+              conversations email interactions notifications public:read public:modify profile profile:modify tags:read
+              tags:modify]
+    after(:build) {|m|
+      m.redirect_uri = m.o_auth_application.redirect_uris[0]
+    }
+  end
+
+  factory :auth_with_read_scopes, class: Api::OpenidConnect::Authorization do
+    o_auth_application
+    association :user, factory: :user_with_aspect
+    scopes %w[openid sub name nickname profile picture gender birthdate locale updated_at contacts:read conversations
+              email interactions notifications private:read public:read profile tags:read]
+    after(:build) {|m|
+      m.redirect_uri = m.o_auth_application.redirect_uris[0]
+    }
+  end
+
+  factory :auth_with_read_scopes_not_private, class: Api::OpenidConnect::Authorization do
+    o_auth_application
+    association :user, factory: :user_with_aspect
+    scopes %w[openid sub name nickname profile picture gender birthdate locale updated_at contacts:read conversations
+              email interactions notifications public:read profile tags:read]
     after(:build) {|m|
       m.redirect_uri = m.o_auth_application.redirect_uris[0]
     }

--- a/spec/integration/api/comments_controller_spec.rb
+++ b/spec/integration/api/comments_controller_spec.rb
@@ -3,8 +3,22 @@
 require "spec_helper"
 
 describe Api::V1::CommentsController do
-  let(:auth) { FactoryGirl.create(:auth_with_read_and_write) }
+  let(:auth) {
+    FactoryGirl.create(
+      :auth_with_profile_only,
+      scopes: %w[openid public:read public:modify private:read private:modify interactions]
+    )
+  }
+
+  let(:auth_public_only) {
+    FactoryGirl.create(
+      :auth_with_profile_only,
+      scopes: %w[openid public:read public:modify interactions]
+    )
+  }
+
   let!(:access_token) { auth.create_access_token.to_s }
+  let!(:access_token_public_only) { auth_public_only.create_access_token.to_s }
 
   before do
     @status = alice.post(
@@ -24,13 +38,27 @@ describe Api::V1::CommentsController do
     )
 
     @comment_on_eves_post = comment_service.create(@eves_post.guid, "Comment on eve's post")
+
+    aspect = auth_public_only.user.aspects.create(name: "first aspect")
+    @private_post = auth_public_only.user.post(
+      "Post",
+      status_message: {text: "This is a private status message"},
+      public:         false,
+      to:             [aspect.id],
+      type:           "Post"
+    )
+    @comment_on_private_post = comment_service(auth_public_only.user).create(@private_post.guid, "Private comment")
   end
 
   describe "#create" do
     context "valid post ID" do
       it "succeeds in adding a comment" do
         comment_text = "This is a comment"
-        create_comment(@status.guid, comment_text)
+        post(
+          api_v1_post_comments_path(post_id: @status.guid),
+          params: {body: comment_text, access_token: access_token}
+        )
+
         expect(response.status).to eq(201)
         comment = response_body(response)
         confirm_comment_format(comment, auth.user, comment_text)
@@ -39,7 +67,10 @@ describe Api::V1::CommentsController do
 
     context "wrong post id" do
       it "fails at adding a comment" do
-        create_comment("999_999_999", "This is a comment")
+        post(
+          api_v1_post_comments_path(post_id: "999_999_999"),
+          params: {body: "text", access_token: access_token}
+        )
         expect(response.status).to eq(404)
         expect(response.body).to eq(I18n.t("api.endpoint_errors.posts.post_not_found"))
       end
@@ -48,9 +79,11 @@ describe Api::V1::CommentsController do
     context "lack of permissions" do
       it "fails at adding a comment" do
         alice.blocks.create(person: auth.user.person)
-        create_comment(@status.guid, "That shouldn't be there because I am ignored by this user")
+        post(
+          api_v1_post_comments_path(post_id: @status.guid),
+          params: {body: "That shouldn't be there because I am ignored by this user", access_token: access_token}
+        )
         expect(response.status).to eq(422)
-        expect(response.body).to eq(I18n.t("api.endpoint_errors.comments.not_allowed"))
       end
     end
   end
@@ -59,8 +92,8 @@ describe Api::V1::CommentsController do
     before do
       @comment_text1 = "This is a comment"
       @comment_text2 = "This is a comment 2"
-      create_comment(@status.guid, @comment_text1)
-      create_comment(@status.guid, @comment_text2)
+      comment_service.create(@status.guid, @comment_text1)
+      comment_service.create(@status.guid, @comment_text2)
     end
 
     context "valid post ID" do
@@ -87,12 +120,23 @@ describe Api::V1::CommentsController do
         expect(response.body).to eq(I18n.t("api.endpoint_errors.posts.post_not_found"))
       end
     end
+
+    context "can't see comment on limited post without private:read token" do
+      it "fails" do
+        get(
+          api_v1_post_comments_path(post_id: @private_post.guid),
+          params: {access_token: access_token_public_only}
+        )
+        expect(response.status).to eq(404)
+        expect(response.body).to eq(I18n.t("api.endpoint_errors.posts.post_not_found"))
+      end
+    end
   end
 
   describe "#delete" do
     before do
-      create_comment(@status.guid, "This is a comment")
-      @comment_guid = response_body(response)["guid"]
+      comment = comment_service.create(@status.guid, "This is a comment")
+      @comment_guid = comment.guid
     end
 
     context "valid comment ID" do
@@ -152,8 +196,8 @@ describe Api::V1::CommentsController do
       end
     end
 
-    context "insufficient permissions (not your comment and not owner)" do
-      it "fails at deleting comment" do
+    context "insufficient permissions" do
+      it "fails at deleting other user's comment on other user's post" do
         alices_comment = comment_service(alice).create(@status.guid, "Alice's comment")
         delete(
           api_v1_post_comment_path(
@@ -165,13 +209,24 @@ describe Api::V1::CommentsController do
         expect(response.status).to eq(403)
         expect(response.body).to eq(I18n.t("api.endpoint_errors.comments.no_delete"))
       end
+
+      it "fails at deleting your comment on post without private:modify token" do
+        delete(
+          api_v1_post_comment_path(
+            post_id: @private_post.guid,
+            id:      @comment_on_private_post.guid
+          ),
+          params: {access_token: access_token_public_only}
+        )
+        expect(response.status).to eq(404)
+      end
     end
   end
 
   describe "#report" do
     before do
-      create_comment(@status.guid, "This is a comment")
-      @comment_guid = response_body(response)["guid"]
+      comment = comment_service.create(@status.guid, "This is a comment")
+      @comment_guid = comment.guid
     end
 
     context "valid comment ID" do
@@ -220,6 +275,40 @@ describe Api::V1::CommentsController do
           params: {
             reason:       "bad comment",
             access_token: access_token
+          }
+        )
+        expect(response.status).to eq(404)
+        expect(response.body).to eq(I18n.t("api.endpoint_errors.posts.post_not_found"))
+      end
+    end
+
+    context "invalid Post ID" do
+      it "fails at reporting comment" do
+        post(
+          api_v1_post_comment_report_path(
+            post_id:    "999_999_999",
+            comment_id: @comment_guid
+          ),
+          params: {
+            reason:       "bad comment",
+            access_token: access_token
+          }
+        )
+        expect(response.status).to eq(404)
+        expect(response.body).to eq(I18n.t("api.endpoint_errors.posts.post_not_found"))
+      end
+    end
+
+    context "lack of private permissions on private post" do
+      it "fails at reporting comment" do
+        post(
+          api_v1_post_comment_report_path(
+            post_id:    @private_post.guid,
+            comment_id: @comment_on_private_post.guid
+          ),
+          params: {
+            reason:       "bad comment",
+            access_token: access_token_public_only
           }
         )
         expect(response.status).to eq(404)
@@ -276,13 +365,6 @@ describe Api::V1::CommentsController do
 
   def comment_service(user=auth.user)
     CommentService.new(user)
-  end
-
-  def create_comment(post_guid, text)
-    post(
-      api_v1_post_comments_path(post_id: post_guid),
-      params: {body: text, access_token: access_token}
-    )
   end
 
   def response_body(response)

--- a/spec/integration/api/contacts_controller_spec.rb
+++ b/spec/integration/api/contacts_controller_spec.rb
@@ -3,13 +3,31 @@
 require "spec_helper"
 
 describe Api::V1::ContactsController do
-  let(:auth) { FactoryGirl.create(:auth_with_read_and_write) }
-  let(:auth_read_only) { FactoryGirl.create(:auth_with_read) }
+  let(:auth) {
+    FactoryGirl.create(
+      :auth_with_profile_only,
+      scopes: %w[openid contacts:read contacts:modify]
+    )
+  }
+
+  let(:auth_read_only) {
+    FactoryGirl.create(
+      :auth_with_profile_only,
+      scopes: %w[openid contacts:read]
+    )
+  }
+
+  let(:auth_profile_only) {
+    FactoryGirl.create(:auth_with_profile_only)
+  }
+
   let!(:access_token) { auth.create_access_token.to_s }
   let!(:access_token_read_only) { auth_read_only.create_access_token.to_s }
+  let!(:access_token_profile_only) { auth_profile_only.create_access_token.to_s }
 
   before do
-    @aspect1 = auth.user.aspects.where(name: "generic").first
+    @aspect1 = auth.user.aspects.create(name: "generic")
+    auth.user.share_with(eve.person, @aspect1)
     @aspect2 = auth.user.aspects.create(name: "another aspect")
     @eve_aspect = eve.aspects.first
   end

--- a/spec/integration/api/conversations_controller_spec.rb
+++ b/spec/integration/api/conversations_controller_spec.rb
@@ -3,12 +3,28 @@
 require "spec_helper"
 
 describe Api::V1::ConversationsController do
-  let(:auth) { FactoryGirl.create(:auth_with_read_and_write) }
+  let(:auth) {
+    FactoryGirl.create(
+      :auth_with_profile_only,
+      scopes: %w[openid conversations]
+    )
+  }
+
+  let(:auth_participant) {
+    FactoryGirl.create(:auth_with_all_scopes)
+  }
+
+  let(:auth_profile_only) {
+    FactoryGirl.create(:auth_with_profile_only)
+  }
+
   let!(:access_token) { auth.create_access_token.to_s }
-  let(:auth_participant) { FactoryGirl.create(:auth_with_read_and_write) }
   let!(:access_token_participant) { auth_participant.create_access_token.to_s }
+  let!(:access_token_profile_only) { auth_profile_only.create_access_token.to_s }
+
 
   before do
+    auth.user.aspects.create(name: "first")
     auth.user.share_with alice.person, auth.user.aspects[0]
     alice.share_with auth.user.person, alice.aspects[0]
     auth.user.disconnected_by(eve)

--- a/spec/integration/api/likes_controller_spec.rb
+++ b/spec/integration/api/likes_controller_spec.rb
@@ -3,8 +3,27 @@
 require "spec_helper"
 
 describe Api::V1::LikesController do
-  let(:auth) { FactoryGirl.create(:auth_with_read_and_write) }
+  let(:auth) {
+    FactoryGirl.create(
+      :auth_with_profile_only,
+      scopes: %w[openid public:read public:modify private:read private:modify interactions]
+    )
+  }
+
+  let(:auth_public_only) {
+    FactoryGirl.create(
+      :auth_with_profile_only,
+      scopes: %w[openid public:read public:modify interactions]
+    )
+  }
+
+  let(:auth_profile_only) {
+    FactoryGirl.create(:auth_with_profile_only)
+  }
+
   let!(:access_token) { auth.create_access_token.to_s }
+  let!(:access_token_public_only) { auth_public_only.create_access_token.to_s }
+  let!(:access_token_profile_only) { auth_profile_only.create_access_token.to_s }
 
   before do
     @status = auth.user.post(
@@ -12,6 +31,15 @@ describe Api::V1::LikesController do
       text:   "This is a status message",
       public: true,
       to:     "all"
+    )
+
+    aspect = auth_public_only.user.aspects.create(name: "first aspect")
+    @private_status = auth_public_only.user.post(
+      "Post",
+      status_message: {text: "This is a private status message"},
+      public:         false,
+      to:             [aspect.id],
+      type:           "Post"
     )
   end
 
@@ -54,6 +82,17 @@ describe Api::V1::LikesController do
         expect(response.body).to eq(I18n.t("api.endpoint_errors.posts.post_not_found"))
       end
     end
+
+    context "without private:read scope in token" do
+      it "fails at getting likes" do
+        get(
+          api_v1_post_likes_path(post_id: @private_status.guid),
+          params: {access_token: access_token_public_only}
+        )
+        expect(response.status).to eq(422)
+        expect(response.body).to eq(I18n.t("api.endpoint_errors.likes.user_not_allowed_to_like"))
+      end
+    end
   end
 
   describe "#create" do
@@ -87,6 +126,15 @@ describe Api::V1::LikesController do
         expect(likes.length).to eq(1)
         expect(likes[0].author.id).to eq(auth.user.person.id)
       end
+
+      it "fails in liking private post without private:modify" do
+        post(
+          api_v1_post_likes_path(post_id: @private_status.guid),
+          params: {access_token: access_token_public_only}
+        )
+        expect(response.status).to eq(422)
+        expect(response.body).to eq(I18n.t("api.endpoint_errors.likes.user_not_allowed_to_like"))
+      end
     end
 
     context "with wrong post id" do
@@ -103,10 +151,7 @@ describe Api::V1::LikesController do
 
   describe "#delete" do
     before do
-      post(
-        api_v1_post_likes_path(post_id: @status.guid),
-        params: {access_token: access_token}
-      )
+      like_service.create(@status.guid)
     end
 
     context "with right post id" do
@@ -136,6 +181,16 @@ describe Api::V1::LikesController do
 
         likes = like_service.find_for_post(@status.guid)
         expect(likes.length).to eq(0)
+      end
+
+      it "fails at unliking private post without private:modify" do
+        like_service(auth_public_only.user).create(@private_status.guid)
+        delete(
+          api_v1_post_likes_path(post_id: @private_status.guid),
+          params: {access_token: access_token}
+        )
+        expect(response.status).to eq(404)
+        expect(response.body).to eq(I18n.t("api.endpoint_errors.posts.post_not_found"))
       end
     end
 

--- a/spec/integration/api/messages_controller_spec.rb
+++ b/spec/integration/api/messages_controller_spec.rb
@@ -3,7 +3,13 @@
 require "spec_helper"
 
 describe Api::V1::MessagesController do
-  let(:auth) { FactoryGirl.create(:auth_with_read_and_write) }
+  let(:auth) {
+    FactoryGirl.create(
+      :auth_with_profile_only,
+      scopes: %w[openid conversations]
+    )
+  }
+
   let!(:access_token) { auth.create_access_token.to_s }
 
   before do

--- a/spec/integration/api/reshares_controller_spec.rb
+++ b/spec/integration/api/reshares_controller_spec.rb
@@ -3,10 +3,21 @@
 require "spec_helper"
 
 describe Api::V1::ResharesController do
-  let(:auth) { FactoryGirl.create(:auth_with_read_and_write) }
+  let(:auth) {
+    FactoryGirl.create(:auth_with_all_scopes)
+  }
+
+  let(:auth_read_only) {
+    FactoryGirl.create(:auth_with_read_scopes)
+  }
+
+  let(:auth_profile_only) {
+    FactoryGirl.create(:auth_with_profile_only)
+  }
+
   let!(:access_token) { auth.create_access_token.to_s }
-  let(:auth_read_only) { FactoryGirl.create(:auth_with_read) }
   let!(:access_token_read_only) { auth_read_only.create_access_token.to_s }
+  let!(:access_token_profile_only) { auth_profile_only.create_access_token.to_s }
 
   before do
     @user_post = auth.user.post(

--- a/spec/integration/api/search_controller_spec.rb
+++ b/spec/integration/api/search_controller_spec.rb
@@ -3,10 +3,30 @@
 require "spec_helper"
 
 describe Api::V1::SearchController do
-  let(:auth) { FactoryGirl.create(:auth_with_read_and_write) }
+  let(:auth) {
+    FactoryGirl.create(
+      :auth_with_profile_only,
+      scopes: %w[openid public:read public:modify private:read private:modify]
+    )
+  }
+
+  let(:auth_read_only) {
+    FactoryGirl.create(
+      :auth_with_profile_only,
+      scopes: %w[openid public:read private:read]
+    )
+  }
+
+  let(:auth_public_only_read_only) {
+    FactoryGirl.create(
+      :auth_with_profile_only,
+      scopes: %w[openid public:read]
+    )
+  }
+
   let!(:access_token) { auth.create_access_token.to_s }
-  let(:auth_read_only) { FactoryGirl.create(:auth_with_read) }
   let!(:access_token_read_only) { auth_read_only.create_access_token.to_s }
+  let!(:access_token_public_only_read_only) { auth_public_only_read_only.create_access_token.to_s }
 
   describe "#user_index" do
     before do
@@ -40,7 +60,7 @@ describe Api::V1::SearchController do
       )
       expect(response.status).to eq(200)
       users = response_body_data(response)
-      expect(users.length).to eq(14)
+      expect(users.length).to eq(15)
     end
 
     it "succeeds by name" do
@@ -77,6 +97,19 @@ describe Api::V1::SearchController do
       get(
         "/api/v1/search/users",
         params: {name_or_handle: "unsearchable@example.org", access_token: access_token}
+      )
+      expect(response.status).to eq(200)
+      users = response_body_data(response)
+      expect(users.length).to eq(0)
+    end
+
+    it "doesn't return hidden accounts who are linked without contacts:read token" do
+      aspect_to = auth_public_only_read_only.user.aspects.create(name: "shared aspect")
+      auth_public_only_read_only.user.share_with(@unsearchable_user, aspect_to)
+
+      get(
+        "/api/v1/search/users",
+        params: {name_or_handle: "unsearchable@example.org", access_token: access_token_public_only_read_only}
       )
       expect(response.status).to eq(200)
       users = response_body_data(response)
@@ -123,16 +156,44 @@ describe Api::V1::SearchController do
         text:   "This is Eve's status message #tag2 #tag3",
         public: true
       )
+
+      aspect = eve.aspects.create(name: "shared aspect")
+      eve.share_with(auth_public_only_read_only.user.person, aspect)
+      eve.share_with(auth.user.person, aspect)
+      @eve_private_post = eve.post(
+        :status_message,
+        text:   "This is Eve's status message #tag2 #tag3",
+        public: false,
+        to:     aspect.id
+      )
     end
 
     it "succeeds by tag" do
+      get(
+        "/api/v1/search/posts",
+        params: {tag: "tag2", access_token: access_token_public_only_read_only}
+      )
+      expect(response.status).to eq(200)
+      posts = response_body_data(response)
+      expect(posts.length).to eq(2)
+    end
+
+    it "only returns public posts without private scope" do
+      get(
+        "/api/v1/search/posts",
+        params: {tag: "tag2", access_token: access_token_public_only_read_only}
+      )
+      expect(response.status).to eq(200)
+      posts = response_body_data(response)
+      expect(posts.length).to eq(2)
+
       get(
         "/api/v1/search/posts",
         params: {tag: "tag2", access_token: access_token}
       )
       expect(response.status).to eq(200)
       posts = response_body_data(response)
-      expect(posts.length).to eq(2)
+      expect(posts.length).to eq(3)
     end
 
     it "fails with missing parameters" do

--- a/spec/integration/api/tag_followings_controller_spec.rb
+++ b/spec/integration/api/tag_followings_controller_spec.rb
@@ -3,12 +3,29 @@
 require "spec_helper"
 
 describe Api::V1::TagFollowingsController do
-  let(:auth) { FactoryGirl.create(:auth_with_read_and_write) }
+  let(:auth) {
+    FactoryGirl.create(
+      :auth_with_profile_only,
+      scopes: %w[openid tags:read tags:modify]
+    )
+  }
+
+  let(:auth_read_only) {
+    FactoryGirl.create(
+      :auth_with_profile_only,
+      scopes: %w[openid tags:read]
+    )
+  }
+
+  let(:auth_profile_only) { FactoryGirl.create(:auth_with_profile_only) }
   let!(:access_token) { auth.create_access_token.to_s }
+  let!(:access_token_read_only) { auth_read_only.create_access_token.to_s }
+  let!(:access_token_profile_only) { auth_profile_only.create_access_token.to_s }
 
   before do
     @expected_tags = %w[tag1 tag2 tag3]
     @expected_tags.each {|tag| add_tag(tag, auth.user) }
+    @expected_tags.each {|tag| add_tag(tag, auth_read_only.user) }
     @initial_count = @expected_tags.length
   end
 
@@ -38,7 +55,7 @@ describe Api::V1::TagFollowingsController do
           params: {access_token: access_token}
         )
 
-        expect(response.status).to eq(400)
+        expect(response.status).to eq(422)
         expect(response.body).to eq(I18n.t("api.endpoint_errors.tags.cant_process"))
       end
     end
@@ -50,8 +67,26 @@ describe Api::V1::TagFollowingsController do
           params: {name: "tag3", access_token: access_token}
         )
 
-        expect(response.status).to eq(400)
+        expect(response.status).to eq(422)
         expect(response.body).to eq(I18n.t("api.endpoint_errors.tags.cant_process"))
+      end
+    end
+
+    context "fails with credentials" do
+      it "insufficient scopes in token" do
+        post(
+          api_v1_tag_followings_path,
+          params: {name: "tag4", access_token: access_token_read_only}
+        )
+        expect(response.status).to eq(403)
+      end
+
+      it "invalid token" do
+        post(
+          api_v1_tag_followings_path,
+          params: {name: "tag4", access_token: "999_999_999"}
+        )
+        expect(response.status).to eq(401)
       end
     end
   end
@@ -61,12 +96,30 @@ describe Api::V1::TagFollowingsController do
       it "succeeds" do
         get(
           api_v1_tag_followings_path,
-          params: {access_token: access_token}
+          params: {access_token: access_token_read_only}
         )
         expect(response.status).to eq(200)
         items = JSON.parse(response.body)
         expect(items.length).to eq(@expected_tags.length)
         @expected_tags.each {|tag| expect(items.find(tag)).to be_truthy }
+      end
+    end
+
+    context "fails with credentials" do
+      it "insufficient scopes in token" do
+        get(
+          api_v1_tag_followings_path,
+          params: {access_token: access_token_profile_only}
+        )
+        expect(response.status).to eq(403)
+      end
+
+      it "invalid token" do
+        get(
+          api_v1_tag_followings_path,
+          params: {access_token: "999_999_999"}
+        )
+        expect(response.status).to eq(401)
       end
     end
   end
@@ -105,6 +158,24 @@ describe Api::V1::TagFollowingsController do
         expect(response.status).to eq(200)
         items = JSON.parse(response.body)
         expect(items.length).to eq(@initial_count)
+      end
+    end
+
+    context "fails with credentials" do
+      it "insufficient scopes in token" do
+        delete(
+          api_v1_tag_following_path("tag1"),
+          params: {access_token: access_token_read_only}
+        )
+        expect(response.status).to eq(403)
+      end
+
+      it "invalid token" do
+        delete(
+          api_v1_tag_following_path("tag1"),
+          params: {access_token: "999_999_999"}
+        )
+        expect(response.status).to eq(401)
       end
     end
   end

--- a/spec/integration/api/user_info_controller_spec.rb
+++ b/spec/integration/api/user_info_controller_spec.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 describe Api::OpenidConnect::UserInfoController do
-  let!(:auth_with_read_and_ppid) { FactoryGirl.create(:auth_with_read_and_ppid) }
+  let!(:auth_with_read_and_ppid) {
+    FactoryGirl.create(:auth_with_profile_and_ppid)
+  }
+
   let!(:access_token_with_read) { auth_with_read_and_ppid.create_access_token.to_s }
 
   describe "#show" do

--- a/spec/integration/api/users_controller_spec.rb
+++ b/spec/integration/api/users_controller_spec.rb
@@ -5,10 +5,46 @@ require "spec_helper"
 describe Api::V1::UsersController do
   include PeopleHelper
 
-  let(:auth) { FactoryGirl.create(:auth_with_read_and_write) }
-  let(:auth_read_only) { FactoryGirl.create(:auth_with_read) }
+  let(:full_scopes) {
+    %w[openid public:read public:modify private:read private:modify contacts:read profile profile:modify]
+  }
+
+  let(:auth) {
+    FactoryGirl.create(
+      :auth_with_profile_only,
+      scopes: full_scopes
+    )
+  }
+
+  let(:auth_public_only) {
+    FactoryGirl.create(
+      :auth_with_profile_only,
+      scopes: %w[openid public:read public:modify]
+    )
+  }
+
+  let(:auth_read_only) {
+    FactoryGirl.create(
+      :auth_with_profile_only,
+      scopes: %w[openid public:read private:read contacts:read profile]
+    )
+  }
+
+  let(:auth_public_only_read_only) {
+    FactoryGirl.create(
+      :auth_with_profile_only,
+      scopes: %w[openid public:read]
+    )
+  }
+
+  let(:auth_profile_only) {
+    FactoryGirl.create(:auth_with_profile_only)
+  }
   let!(:access_token) { auth.create_access_token.to_s }
+  let!(:access_token_public_only) { auth_public_only.create_access_token.to_s }
   let!(:access_token_read_only) { auth_read_only.create_access_token.to_s }
+  let!(:access_token_public_only_read_only) { auth_public_only_read_only.create_access_token.to_s }
+  let!(:access_token_profile_only) { auth_profile_only.create_access_token.to_s }
 
   describe "#show" do
     context "Current User" do
@@ -49,7 +85,8 @@ describe Api::V1::UsersController do
       it "succeeds with in Aspect valid user" do
         alice.profile[:public_details] = true
         alice.profile.save
-        auth.user.share_with(alice.person, auth.user.aspects.first)
+        aspect = auth.user.aspects.create(name: "first")
+        auth.user.share_with(alice.person, aspect)
         get(
           "/api/v1/users/#{alice.guid}",
           params: {access_token: access_token}
@@ -86,10 +123,29 @@ describe Api::V1::UsersController do
 
       it "fails if invalid token" do
         get(
-          api_v1_user_path(alice.person.guid),
+          "/api/v1/users/#{alice.guid}",
           params: {access_token: "999_999_999"}
         )
         expect(response.status).to eq(401)
+      end
+
+      it "fails for private profile if don't have contacts:read" do
+        unsearchable_user = FactoryGirl.create(
+          :person,
+          diaspora_handle: "unsearchable@example.org",
+          profile:         FactoryGirl.build(
+            :profile,
+            first_name: "Unsearchable",
+            last_name:  "Person",
+            searchable: false
+          )
+        )
+
+        get(
+          "/api/v1/users/#{unsearchable_user.guid}",
+          params: {access_token: access_token_profile_only}
+        )
+        expect(response.status).to eq(404)
       end
 
       it "fails with invalid user GUID" do
@@ -240,7 +296,8 @@ describe Api::V1::UsersController do
       contacts = response_body_data(response)
       expect(contacts.length).to eq(0)
 
-      auth.user.share_with(alice.person, auth.user.aspects.first)
+      aspect = auth.user.aspects.create(name: "first")
+      auth.user.share_with(alice.person, aspect)
       get(
         api_v1_user_contacts_path(auth.user.guid),
         params: {access_token: access_token}
@@ -269,6 +326,14 @@ describe Api::V1::UsersController do
       expect(response.body).to eq(I18n.t("api.endpoint_errors.users.not_found"))
     end
 
+    it "fails if insufficient scope token" do
+      get(
+        api_v1_user_contacts_path(alice.guid),
+        params: {access_token: access_token_public_only_read_only}
+      )
+      expect(response.status).to eq(403)
+    end
+
     it "fails if invalid token" do
       get(
         api_v1_user_contacts_path(alice.guid),
@@ -284,10 +349,10 @@ describe Api::V1::UsersController do
       alice.share_with(eve.person, alice_private_spec)
       alice.share_with(auth.user.person, alice.aspects.first)
 
-      auth.user.post(:photo, pending: false, user_file: File.open(photo_fixture_name), to: "all")
-      auth.user.post(:photo, pending: false, user_file: File.open(photo_fixture_name), to: "all")
-      @public_photo1 = alice.post(:photo, pending: false, user_file: File.open(photo_fixture_name), to: "all")
-      @public_photo2 = alice.post(:photo, pending: false, user_file: File.open(photo_fixture_name), to: "all")
+      auth.user.post(:photo, pending: false, user_file: File.open(photo_fixture_name), public: true)
+      auth.user.post(:photo, pending: false, user_file: File.open(photo_fixture_name), public: true)
+      @public_photo1 = alice.post(:photo, pending: false, user_file: File.open(photo_fixture_name), public: true)
+      @public_photo2 = alice.post(:photo, pending: false, user_file: File.open(photo_fixture_name), public: true)
       @shared_photo1 = alice.post(:photo, pending: false, user_file: File.open(photo_fixture_name),
                                   to: alice.aspects.first.id)
       @private_photo1 = alice.post(:photo, pending: false, user_file: File.open(photo_fixture_name),
@@ -307,6 +372,19 @@ describe Api::V1::UsersController do
         expect(guids).to include(@public_photo1.guid, @public_photo2.guid, @shared_photo1.guid)
         expect(guids).not_to include(@private_photo1.guid)
         confirm_photos(photos)
+      end
+
+      it "returns only public photos of other user without private:read scope in token" do
+        get(
+          api_v1_user_photos_path(alice.guid),
+          params: {access_token: access_token_public_only_read_only}
+        )
+        expect(response.status).to eq(200)
+        photos = response_body_data(response)
+        expect(photos.length).to eq(2)
+        guids = photos.map {|photo| photo["guid"] }
+        expect(guids).to include(@public_photo1.guid, @public_photo2.guid)
+        expect(guids).not_to include(@private_photo1.guid, @shared_photo1.guid)
       end
 
       it "returns logged in user's photos" do
@@ -344,10 +422,11 @@ describe Api::V1::UsersController do
       alice.share_with(eve.person, alice_private_spec)
       alice.share_with(auth.user.person, alice.aspects.first)
 
-      auth.user.post(:status_message, text: "auth user message1", public: true, to: "all")
-      auth.user.post(:status_message, text: "auth user message2", public: true, to: "all")
-      @public_post1 = alice.post(:status_message, text: "alice public message1", public: true, to: "all")
-      @public_post2 = alice.post(:status_message, text: "alice public message2", public: true, to: "all")
+      auth.user.post(:status_message, text: "auth user message1", public: true)
+      auth.user.post(:status_message, text: "auth user message2", public: true)
+      auth.user.post(:status_message, text: "auth user message3", public: false, to: "all")
+      @public_post1 = alice.post(:status_message, text: "alice public message1", public: true)
+      @public_post2 = alice.post(:status_message, text: "alice public message2", public: true)
       @shared_post1 = alice.post(:status_message, text: "alice limited to auth user message",
                                  public: false, to: alice.aspects.first.id)
       @private_post1 = alice.post(:status_message, text: "alice limited hidden from auth user message",
@@ -374,6 +453,16 @@ describe Api::V1::UsersController do
         get(
           api_v1_user_posts_path(auth.user.guid),
           params: {access_token: access_token}
+        )
+        expect(response.status).to eq(200)
+        posts = response_body_data(response)
+        expect(posts.length).to eq(3)
+      end
+
+      it "returns public posts only without private:read scope in token" do
+        get(
+          api_v1_user_posts_path(auth.user.guid),
+          params: {access_token: access_token_public_only_read_only}
         )
         expect(response.status).to eq(200)
         posts = response_body_data(response)

--- a/spec/lib/api/openid_connect/protected_resource_endpoint_spec.rb
+++ b/spec/lib/api/openid_connect/protected_resource_endpoint_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Api::OpenidConnect::ProtectedResourceEndpoint, type: :request do
-  let(:auth_with_read) { FactoryGirl.create(:auth_with_read) }
+  let(:auth_with_read) { FactoryGirl.create(:auth_with_read_scopes) }
   let!(:access_token_with_read) { auth_with_read.create_access_token.to_s }
   let!(:expired_access_token) do
     access_token = auth_with_read.o_auth_access_tokens.create!

--- a/spec/lib/api/openid_connect/token_endpoint_spec.rb
+++ b/spec/lib/api/openid_connect/token_endpoint_spec.rb
@@ -64,9 +64,11 @@ describe Api::OpenidConnect::TokenEndpoint, type: :request do
       end
 
       it "should not allow a nil code" do
-        post api_openid_connect_access_tokens_path, params: {grant_type: "authorization_code",
-             client_id: client.client_id, client_secret: client.client_secret,
-             redirect_uri: "http://localhost:3000/", code: nil}
+        post api_openid_connect_access_tokens_path, params: {grant_type:    "authorization_code",
+                                                             client_id:     client.client_id,
+                                                             client_secret: client.client_secret,
+                                                             redirect_uri:  "http://localhost:3000/",
+                                                             code:          nil}
         expect(JSON.parse(response.body)["error"]).to eq("invalid_request")
       end
     end

--- a/spec/models/api/openid_connect/id_token_spec.rb
+++ b/spec/models/api/openid_connect/id_token_spec.rb
@@ -2,7 +2,7 @@
 
 describe Api::OpenidConnect::IdToken, type: :model do
   describe "#to_jwt" do
-    let(:auth) { FactoryGirl.create(:auth_with_read) }
+    let(:auth) { FactoryGirl.create(:auth_with_profile_only) }
     let(:id_token) { Api::OpenidConnect::IdToken.new(auth, "nonce") }
 
     describe "decoded data" do

--- a/spec/services/post_service_spec.rb
+++ b/spec/services/post_service_spec.rb
@@ -181,6 +181,13 @@ describe PostService do
       PostService.new(alice).destroy(post.id)
     end
 
+    it "won't delete private post if explicitly unallowed" do
+      expect {
+        PostService.new(alice).destroy(post.id, false)
+      }.to raise_error Diaspora::NonPublic
+      expect(StatusMessage.find_by(id: post.id)).not_to be_nil
+    end
+
     it "will not let you destroy posts visible to you but that you do not own" do
       expect {
         PostService.new(bob).destroy(post.id)

--- a/spec/shared_behaviors/account_migration.rb
+++ b/spec/shared_behaviors/account_migration.rb
@@ -176,7 +176,7 @@ shared_examples_for "it updates user references" do
   end
 
   it "updates authorization refrences" do
-    authorization = FactoryGirl.create(:auth_with_read, user: old_user)
+    authorization = FactoryGirl.create(:auth_with_read_scopes, user: old_user)
     run_migration
     expect(authorization.reload.user).to eq(new_user)
   end


### PR DESCRIPTION
The changes for the scopes update for the new spec and getting the refresh token added so can be used by clients who respond with the Authorization Code flow or token-request branch of the hybrid flow.  The PR for new scopes hasn't been merged yet. You can find it here: https://github.com/diaspora/api-documentation/pull/12